### PR TITLE
Add module tracking for students

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,22 @@ def init_db():
             )
             """
         )
+        c.execute(
+            "CREATE TABLE IF NOT EXISTS modules (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE)"
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS student_modules (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                student_id INTEGER,
+                module_id INTEGER,
+                status TEXT DEFAULT 'open',
+                completion_date TEXT,
+                FOREIGN KEY(student_id) REFERENCES students(id),
+                FOREIGN KEY(module_id) REFERENCES modules(id)
+            )
+            """
+        )
         conn.commit()
 
 
@@ -67,10 +83,71 @@ def add_progress_to_db(name, entry):
             )
             conn.commit()
 
+def add_module_to_db(name):
+    with sqlite3.connect(DB_FILE) as conn:
+        c = conn.cursor()
+        c.execute("INSERT OR IGNORE INTO modules(name) VALUES (?)", (name,))
+        conn.commit()
+
+def get_module_names():
+    with sqlite3.connect(DB_FILE) as conn:
+        c = conn.cursor()
+        c.execute("SELECT name FROM modules")
+        return [row[0] for row in c.fetchall()]
+
+def assign_module_to_student(student, module):
+    with sqlite3.connect(DB_FILE) as conn:
+        c = conn.cursor()
+        c.execute("SELECT id FROM students WHERE name=?", (student,))
+        sid = c.fetchone()
+        c.execute("SELECT id FROM modules WHERE name=?", (module,))
+        mid = c.fetchone()
+        if sid and mid:
+            c.execute(
+                "INSERT INTO student_modules(student_id, module_id, status) VALUES (?, ?, 'open')",
+                (sid[0], mid[0]),
+            )
+            conn.commit()
+
+def complete_module(student, module):
+    with sqlite3.connect(DB_FILE) as conn:
+        c = conn.cursor()
+        c.execute("SELECT id FROM students WHERE name=?", (student,))
+        sid = c.fetchone()
+        c.execute("SELECT id FROM modules WHERE name=?", (module,))
+        mid = c.fetchone()
+        if sid and mid:
+            c.execute(
+                "UPDATE student_modules SET status='done', completion_date=DATE('now') WHERE student_id=? AND module_id=?",
+                (sid[0], mid[0]),
+            )
+            conn.commit()
+
+def get_student_modules():
+    with sqlite3.connect(DB_FILE) as conn:
+        c = conn.cursor()
+        c.execute("SELECT id, name FROM students")
+        result = {}
+        for sid, sname in c.fetchall():
+            c.execute(
+                """
+                SELECT modules.name, student_modules.status, IFNULL(student_modules.completion_date, '')
+                FROM student_modules
+                JOIN modules ON modules.id = student_modules.module_id
+                WHERE student_modules.student_id = ?
+                """,
+                (sid,),
+            )
+            result[sname] = [
+                {"module": row[0], "status": row[1], "date": row[2]} for row in c.fetchall()
+            ]
+        return result
+
 @app.route('/')
 def index():
     students = get_all_data()
-    return render_template('index.html', students=students)
+    modules = get_student_modules()
+    return render_template('index.html', students=students, modules=modules)
 
 @app.route('/student/add', methods=['GET', 'POST'])
 def add_student():
@@ -89,6 +166,36 @@ def add_progress():
         add_progress_to_db(name, progress)
         return redirect(url_for('index'))
     return render_template('add_progress.html', students=students)
+
+@app.route('/module/add', methods=['GET', 'POST'])
+def add_module():
+    if request.method == 'POST':
+        name = request.form['name']
+        add_module_to_db(name)
+        return redirect(url_for('index'))
+    return render_template('add_module.html')
+
+@app.route('/module/assign', methods=['GET', 'POST'])
+def assign_module_route():
+    students = get_student_names()
+    modules = get_module_names()
+    if request.method == 'POST':
+        student = request.form['student']
+        module = request.form['module']
+        assign_module_to_student(student, module)
+        return redirect(url_for('index'))
+    return render_template('assign_module.html', students=students, modules=modules)
+
+@app.route('/module/complete', methods=['GET', 'POST'])
+def complete_module_route():
+    students = get_student_names()
+    modules = get_module_names()
+    if request.method == 'POST':
+        student = request.form['student']
+        module = request.form['module']
+        complete_module(student, module)
+        return redirect(url_for('index'))
+    return render_template('complete_module.html', students=students, modules=modules)
 
 if __name__ == '__main__':
     init_db()

--- a/templates/add_module.html
+++ b/templates/add_module.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Module toevoegen</h2>
+<form method="post">
+    <label>Naam:</label>
+    <input type="text" name="name" required>
+    <input type="submit" value="Opslaan">
+</form>
+{% endblock %}

--- a/templates/assign_module.html
+++ b/templates/assign_module.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Module koppelen aan student</h2>
+<form method="post">
+    <label>Student:</label>
+    <select name="student">
+        {% for s in students %}
+        <option value="{{ s }}">{{ s }}</option>
+        {% endfor %}
+    </select><br>
+    <label>Module:</label>
+    <select name="module">
+        {% for m in modules %}
+        <option value="{{ m }}">{{ m }}</option>
+        {% endfor %}
+    </select>
+    <input type="submit" value="Opslaan">
+</form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,10 @@
     <nav>
         <a href="{{ url_for('index') }}">Home</a> |
         <a href="{{ url_for('add_student') }}">Student toevoegen</a> |
-        <a href="{{ url_for('add_progress') }}">Voortgang toevoegen</a>
+        <a href="{{ url_for('add_progress') }}">Voortgang toevoegen</a> |
+        <a href="{{ url_for('add_module') }}">Module toevoegen</a> |
+        <a href="{{ url_for('assign_module_route') }}">Module koppelen</a> |
+        <a href="{{ url_for('complete_module_route') }}">Module afronden</a>
     </nav>
     <hr>
     {% block content %}{% endblock %}

--- a/templates/complete_module.html
+++ b/templates/complete_module.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Module afronden</h2>
+<form method="post">
+    <label>Student:</label>
+    <select name="student">
+        {% for s in students %}
+        <option value="{{ s }}">{{ s }}</option>
+        {% endfor %}
+    </select><br>
+    <label>Module:</label>
+    <select name="module">
+        {% for m in modules %}
+        <option value="{{ m }}">{{ m }}</option>
+        {% endfor %}
+    </select>
+    <input type="submit" value="Markeer afgerond">
+</form>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,19 @@
             <li>{{ p }}</li>
             {% endfor %}
         </ul>
+        <h4>Modules</h4>
+        <ul>
+            {% for m in modules.get(name, []) %}
+            <li>
+                {{ m.module }} -
+                {% if m.status == 'done' %}
+                    afgerond op {{ m.date }}
+                {% else %}
+                    bezig
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
     </li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- extend DB with modules and student_modules tables
- allow modules to be added, assigned and completed
- show module status per student on index page
- add pages to create and manage modules

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6840a6b28028832dbfe26d5a760ab288